### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -3,6 +3,9 @@ name: pre-commit
 on:
   push:
 
+permissions:
+  contents: read
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Standard-Cloud/cshelve/security/code-scanning/1](https://github.com/Standard-Cloud/cshelve/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow file. Since the workflow does not appear to require `write` access, we can set the permissions to `contents: read`, which is the minimal permission required for most workflows. This change will ensure that the `GITHUB_TOKEN` has limited access, reducing the risk of unintended actions.

The `permissions` block should be added at the root level of the workflow file, applying to all jobs in the workflow. This approach is simple and effective for workflows with minimal permission requirements.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
